### PR TITLE
Check foreground window title to determine whether or not we should render the overlay.

### DIFF
--- a/necro_gauge.py
+++ b/necro_gauge.py
@@ -1,13 +1,24 @@
+from PIL import Image
+from concurrent.futures import ThreadPoolExecutor
+from PyQt5 import QtCore, QtGui
+from PyQt5.QtCore import QTimer, Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QLabel,
+    QWidget,
+    QVBoxLayout,
+    QSlider,
+    QPushButton,
+    QShortcut,
+    QGroupBox,
+    QLineEdit,
+    QComboBox
+)
+from PyQt5.QtGui import QPixmap, QImage, QKeySequence
 import cv2
 import numpy as np
 import mss
 import json
-from concurrent.futures import ThreadPoolExecutor
-from PyQt5 import QtCore, QtGui
-from PyQt5.QtCore import QTimer, Qt
-from PyQt5.QtWidgets import QApplication, QLabel, QWidget, QVBoxLayout, QSlider, QHBoxLayout, QPushButton, QShortcut, QGroupBox, QLineEdit, QComboBox
-from PyQt5.QtGui import QPixmap, QImage, QKeySequence
-from PIL import Image
 import sys
 import os
 import pygame
@@ -141,7 +152,7 @@ class ImageDisplay(QWidget):
         self.resolution_dropdown.setParent(None)
         self.confirmResolution_button.setParent(None)
         self.slider_box.setTitle("Window Scaling Settings")
-        
+
 
         if self.resolution_dropdown.currentText()=='custom':
             self.slider_box.setGeometry(800, 200, 500, 200)
@@ -308,10 +319,10 @@ class ImageDisplay(QWidget):
 
     def updateImageProperties(self):
         global scale, image_position
-        
+
         # Update scale
         scale = self.scale_slider.value() / 100.0
-        
+
         # Update position
         image_position['x'] = self.x_slider.value()
         image_position['y'] = self.y_slider.value()
@@ -341,7 +352,7 @@ class ImageDisplay(QWidget):
         value = self.update_rate_slider.value()
         self.update_rate_label.setText(f'Update Rate: {value} ms')
         self.update_rate_textbox.setText(str(value))
-    
+
     def updateRateTextChanged(self):
         try:
             value = int(self.update_rate_textbox.text())
@@ -403,7 +414,7 @@ class ImageDisplay(QWidget):
         windows_scaling = config.get('windows_scaling', 150)
         buffbar_size = config.get('buffbar_size', 'medium')
         update_rate = config.get('update_rate', 50)
-        if resolution=='custom':
+        if resolution == 'custom':
             asset_path_prefix = os.path.join('custom_assets', str(windows_scaling), buffbar_size)
         else:
             asset_path_prefix = os.path.join(base_path, 'assets', resolution, str(windows_scaling), buffbar_size)
@@ -536,6 +547,7 @@ class ImageDisplay(QWidget):
             os.execl(sys.executable, sys.executable, *sys.argv)
         except Exception as e:
             print(f"Error restarting script: {e}")
+
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)


### PR DESCRIPTION
No added dependencies since `ctypes` ships with Python.

Benchmark of `showFrame` before and after this addition, in milliseconds:

Before

```
pygame 2.6.0 (SDL 2.28.4, Python 3.12.2)
Hello from the pygame community. https://www.pygame.org/contribute.html
9.488999999999999
9.469
9.438
9.491
9.035
9.475000000000001
9.506
9.479
9.485000000000001
9.475000000000001
8.964
8.996
9.476
9.494000000000002
8.982000000000001
9.479
9.472
9.484
8.954
9.462
8.964
9.471
8.98
9.494000000000002
9.479
```

After

```
pygame 2.6.0 (SDL 2.28.4, Python 3.12.2)
Hello from the pygame community. https://www.pygame.org/contribute.html
13.494000000000002
9.952
13.965
8.974
9.449000000000002
10.019
9.979
9.469
9.438
9.467
8.940999999999999
9.461
9.455
8.974
8.982000000000001
9.0
8.456
9.459
8.952
8.971
```

To quell **any** fear that Jagex might possibly monitor and subsequently misconstrue the use of `GetForegroundWindow()`, here is a screenshot of the only function in the `rs2client` binary that utilizes `SetWindowsHook` or any of its' derivatives:

![image](https://github.com/zyoNoob/zyonsRS3NecroGauge/assets/175177566/4f30bf7c-d195-418d-b4c1-a23c11a28116)

This is for their mouse movement heuristics. No other hooks are placed at any point in time. Jagex, rightfully, does not monitor the use of this function as it has infinitely more legitimate use-cases than illegitimate. 